### PR TITLE
「今後の来訪意向」の各グラフの空白文字を無回答に変更しました。

### DIFF
--- a/comment-wish.html
+++ b/comment-wish.html
@@ -64,7 +64,7 @@
         let cnt = 0;
         const s = [];
         //const sgoodbad = ArrayUtil.toUnique(data.map(d => d.今後の来訪意向));
-        const sgoodbad = ["また行きたい（1年以内）", "福井県在住", "機会があれば行きたい", "あまり行きたいと思わない", "どちらともいえない", "行きたくない", ""];
+        const sgoodbad = ["また行きたい（1年以内）", "福井県在住", "機会があれば行きたい", "あまり行きたいと思わない", "どちらともいえない", "行きたくない", "無回答"];
         const sumgoodbad = sgoodbad.map(s => {
           return { name: s, value: 0 };
         });
@@ -82,7 +82,11 @@
             continue;
           }
           
-          const ngoodbad = sgoodbad.indexOf(d.今後の来訪意向);
+          let wish = d.今後の来訪意向;
+          if (!wish) {
+            wish = "無回答";
+          }
+          const ngoodbad = sgoodbad.indexOf(wish);
           sumgoodbad[ngoodbad].value++;
           
           const comment = d.福井県に求めるもの;
@@ -95,7 +99,11 @@
             if (filterarea && n == "回答エリア2") {
               continue;
             }
-            s.push(`${n}: ${d[n]}`);
+            let value = d[n];
+            if (!value && n === "今後の来訪意向") {
+              value = "無回答";
+            }
+            s.push(`${n}: ${value}`);
           }
           s.push("<hr>");
           if (cnt++ == nshow) {

--- a/index.html
+++ b/index.html
@@ -153,7 +153,10 @@
             case CHART_INDEX_SINGLE:
               for (const d of csv2) {
                 surveySelector.convertData(name, d);
-                const v = d[name];
+                let v = d[name];
+                if (!v && name === "今後の来訪意向") {
+                  v = "無回答";
+                }
                 if (!data[v]) {
                   data[v] = 1;
                 } else {

--- a/trend.html
+++ b/trend.html
@@ -43,9 +43,16 @@
       const sortData = (key, obj) => {
         const names = surveySelector.sortSelectCodes(key, Object.keys(obj));
         const res = {};
-        for (const name of names) {
+
+        const filteredNames = names.filter(name => name !== "無回答");
+        for (const name of filteredNames) {
           res[name] = obj[name];
         }
+        
+        if (obj["無回答"]) {
+          res["無回答"] = obj["無回答"];
+        }
+
         return res;
       };
       
@@ -66,7 +73,10 @@
             const data = {};
             for (const d of csv2) {
               surveySelector.convertData(name, d);
-              const v = d[name];
+              let v = d[name];
+              if (!v && name === "今後の来訪意向") {
+                v = "無回答";
+              }
               if (!data[v]) {
                 data[v] = _.cloneDeep(lineBaseData);
               }


### PR DESCRIPTION
## 概要
<img width="304" height="252" alt="スクリーンショット 2026-02-03 15 06 39" src="https://github.com/user-attachments/assets/ea29fb38-9b6a-4888-b2fd-059ad06fdeac" />

[福井県観光アンケート オープンデータ簡易分析](https://code4fukui.github.io/fukui-kanko-stat/)
凡例に「２」と表示されていた

<img width="304" height="252" alt="スクリーンショット 2026-02-03 15 06 51" src="https://github.com/user-attachments/assets/6253ea34-8dda-4c19-938b-26db7fde43bc" />

[来訪意向と福井県に求めるもの](https://code4fukui.github.io/fukui-kanko-stat/comment-wish.html#0,0,0)
水色部分の凡例が空文字だった

<img width="1450" height="546" alt="スクリーンショット 2026-02-03 15 06 21" src="https://github.com/user-attachments/assets/28d48899-c2f6-47d9-b4fe-996da8b6aa67" />

[福井県観光アンケートトレンド](https://code4fukui.github.io/fukui-kanko-stat/trend.html)
凡例に空文字があった
上記３点を修正した

## 変更
- 「福井県観光アンケート オープンデータ簡易分析」の「今後の来訪意向」グラフで「2」と表示されていた凡例があったので無回答になるように変更
- 「来訪意向と福井県に求めるもの」の円グラフの水色の凡例が空文字、コメント一覧の「今後の来訪意向」が空文字になっていたので無回答に変更
- 「福井県観光アンケートトレンド」の「今後の来訪意向」グラフで凡例が空文字になっていたので無回答に変更し、一番下にくるように変更