### PR TITLE
2期間比較時のfetchMonthレースコンディションを修正

### DIFF
--- a/getSurvey.js
+++ b/getSurvey.js
@@ -4,10 +4,10 @@ import { Day } from "https://js.sabae.cc/DateTime.js";
 const csv = [];
 const month = {};
 const fetchMonth = async (ym) => {
-  if (month[ym]) return;
-  month[ym] = true;
-  const url = "https://code4fukui.github.io/fukui-kanko-survey/monthly/" + ym + ".csv";
-  const data = await CSV.fetchJSON(url);
+  if (month[ym]) return month[ym];
+  month[ym] = (async () => {
+    const url = "https://code4fukui.github.io/fukui-kanko-survey/monthly/" + ym + ".csv";
+    const data = await CSV.fetchJSON(url);
   data.forEach(i => {
     if (i.登録エリア == "スーベニアショップ ラプトル エリア" || i.登録エリア == "スーベニアショップふらぷとる エリア") {
       i.登録エリア = "かつやま恐竜の森 エリア";
@@ -191,6 +191,8 @@ const fetchMonth = async (ym) => {
     }
     csv.push(i);
   });
+  })();
+  return month[ym];
 };
 
 export const getSurvey = async (fromd, tod) => {


### PR DESCRIPTION
## Summary
- `fetchMonth`のキャッシュをboolean(`true`)からPromiseに変更
- 2期間比較で`show1()`と`show2()`が並行実行された際、後発の呼び出しがfetch完了を待機するようになった
- 例: 6/27〜7/27の範囲で7月1日以降のデータしか表示されない問題を修正

## 原因
`fetchMonth`が`month[ym] = true`をfetch開始前に設定していたため、並行する呼び出しがデータ未取得のまま即`return`していた。

## Test plan
- [ ] デフォルト日付範囲で2期間比較をONにし、両期間のデータ件数が一致することを確認
- [ ] 片方の期間の日付を変更して正しくフィルタされることを確認
- [ ] セレクトフィルタ変更時に両期間が正しく更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)